### PR TITLE
Add `lang="ts"` to `<script>` tag

### DIFF
--- a/grammars/svelte.json
+++ b/grammars/svelte.json
@@ -263,7 +263,7 @@
             ]
         },
         {
-            "begin": "(<)(script)\\b(?=[^>]*(?:type=('text/typescript'|\"text/typescript\")|lang=(typescript|'typescript'|\"typescript\")))(?![^/>]*/>\\s*$)",
+            "begin": "(<)(script)\\b(?=[^>]*(?:type=('text/typescript'|\"text/typescript\")|lang=(typescript|'typescript'|\"typescript\"|ts|'ts'|\"ts\")))(?![^/>]*/>\\s*$)",
             "beginCaptures": {
                 "1": {
                     "name": "punctuation.definition.tag.begin.html"


### PR DESCRIPTION
Currently the regex doesn't support `<script lang="ts">`
Which currently is the correct way to declare typescript in a Svelte file.

There are syntax highlighters like [`starry-night`](https://github.com/wooorm/starry-night#languages) that currently rely on this grammar.